### PR TITLE
fix: fixed a bug where db writes were performed on every snapshot

### DIFF
--- a/src/lib/cron/snapshot.ts
+++ b/src/lib/cron/snapshot.ts
@@ -8,6 +8,25 @@ export async function takeSnapshot() {
 
   for (const user of users) {
     const newSnapshot = await fetchGitHubFollowersForUser(user, GITHUB_PAT!);
+    const prevSnapshots = await db().getRecentSnapshotsForUser(user.githubId);
+    const latestSnapshot = prevSnapshots[0] ?? [];
+
+    const prevUsernames = new Set(latestSnapshot.map((f) => f.username));
+    const newUsernames = new Set(newSnapshot.map((f) => f.username));
+
+    const isSameLength = prevUsernames.size === newUsernames.size;
+    const isSameSet =
+      isSameLength &&
+      [...newUsernames].every((username) => prevUsernames.has(username));
+
+    if (isSameSet) {
+      console.log(
+        `No change in snapshot for ${user.username}. Skipping insert.`
+      );
+      continue;
+    }
+
     await db().addFollowers(newSnapshot, user.githubId);
+    console.log(`New snapshot inserted for ${user.username}`);
   }
 }

--- a/src/lib/cron/summary.ts
+++ b/src/lib/cron/summary.ts
@@ -16,6 +16,9 @@ export async function sendWeeklySummaries() {
     const newFollowers = latest.filter((f) => !previousSet.has(f.username));
     const ghosts = previous.filter((f) => !currentSet.has(f.username));
 
+    newFollowers.sort((a, b) => a.username.localeCompare(b.username));
+    ghosts.sort((a, b) => a.username.localeCompare(b.username));
+
     if (newFollowers.length === 0 && ghosts.length === 0) continue;
 
     await sendEmail({


### PR DESCRIPTION
this is bad, the db operation should only be called when the cached data is different from the new one from the most recent snapshot.

make db no go blow;