### PR TITLE
fix: track first follow date to prevent false new follower reports

### DIFF
--- a/scripts/migrations/00012_fixed_timestamp_for_follower/index.sql
+++ b/scripts/migrations/00012_fixed_timestamp_for_follower/index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE followers ADD CONSTRAINT unique_follower_per_user UNIQUE (username, github_id)

--- a/src/lib/cron/summary.ts
+++ b/src/lib/cron/summary.ts
@@ -14,7 +14,7 @@ export async function sendWeeklySummaries() {
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
     const recentGhosts = ghosts.filter((g) => g.unfollowedAt >= oneWeekAgo);
     const newFollowers = currrentFollowers.filter(
-      (f) => f.fetchedAt >= oneWeekAgo
+      (f) => f.firstFollowedAt >= oneWeekAgo
     );
 
     if (newFollowers.length === 0 && recentGhosts.length === 0) continue;


### PR DESCRIPTION
the weekly summary was incorrectly reporting all current followers as "new" because `fetchedAt` was being updated on every bi-hourly snapshot.

i've added a first_followed_at column to track when someone initially followed. The timestamp would be constant remaining unchanged.

this ensures the weekly summary only shows followers who actually followed within the past 7 days, not everyone whose data was recently fetched.